### PR TITLE
docker: demo for home and nginx

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 node_modules/
 .git/
+Dockerfile
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,14 @@ COPY package.json /usr/src/app/
 COPY package-lock.json /usr/src/app/
 RUN npm install
 COPY . /usr/src/app/
-# build sparnatural into dist/ folder
+# build sparnatural.js and sparnatural.css from src into dist/ folder
 RUN npm run build
+# prepare the home page (demo-dbpedia-v2) with the latest sparnatural.js|css build 
+RUN git clone https://github.com/sparna-git/sparnatural.eu.git /tmp/sparnatural.eu/
+RUN cp -f /usr/src/app/dist/sparnatural.* /tmp/sparnatural.eu/demos/demo-dbpedia-v2/
 
-
-### start a nginx web server to serve the dist/ folder
+### start a nginx web server to serve the demo-dbpedia-v2/ folder
 FROM nginx:1.21.6
-COPY --from=sparnatural-builder /usr/src/app/dist/ /usr/share/nginx/html/
+COPY --from=sparnatural-builder /tmp/sparnatural.eu/demos/demo-dbpedia-v2/ /usr/share/nginx/html/
 RUN chown nginx.nginx /usr/share/nginx/html/ -R
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
-FROM node:14
-
+### build sparnatural
+FROM node:14 as sparnatural-builder
 # to have latest npm version
 RUN npm i -g npm
-
 # install needed npm dependancies for build step
 WORKDIR /usr/src/app/
 COPY package.json /usr/src/app/
 COPY package-lock.json /usr/src/app/
 RUN npm install
 COPY . /usr/src/app/
-
 # build sparnatural into dist/ folder
 RUN npm run build
 
-# start a http server on the dist/folder
-RUN npm install -g http-server
-CMD [ "http-server", "-p", "8080", "/usr/src/app/dist/"]
-EXPOSE 8080
+
+### start a nginx web server to serve the dist/ folder
+FROM nginx:1.21.6
+COPY --from=sparnatural-builder /usr/src/app/dist/ /usr/share/nginx/html/
+RUN chown nginx.nginx /usr/share/nginx/html/ -R
+EXPOSE 80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,5 +8,5 @@ services:
     container_name: sparnatural
     restart: unless-stopped
     ports:
-      - 8080:8080
+      - 8080:80
 


### PR DESCRIPTION
I switched to nginx for the web server and I just changed the default homepage to demo-dbpedia-v2 into the docker container.
Now it's https://github.com/sparna-git/sparnatural.eu/tree/main/demos/demo-dbpedia-v2 and I erased sparnatural.js and sparnatural.css with the latest just built version. And I just ignored the dist/index.html (sandbox for dev). I did not understood why there is a similar folder at https://github.com/sparna-git/Sparnatural/tree/master/sparnatural-demo-dbpedia but I ignored it because it seems to be older. Hope this is ok ?
Thanks to this step, users should have a working sparnatural example instance on hand running the docker container.

But there is a strange box with the "Montrer le nom des colonnes" toggle, is it ok ? see the screen bellow:

![image](https://user-images.githubusercontent.com/328244/152657655-1ae99665-0c62-47e7-87d9-95060e22b4b0.png)

---

Then I'm thinking about other features:

1) Be able to customize the index.html and Sparnatural parameters with docker external parameters. I'm not familiar with sparnatural so maybe I miss something. If I understand well how sparnatural works, we could give a docker example to overload `sparnatural-config.ttl` and `sampleQueries.js` files. This is possible in the docker world using a volume so that it's possible to inject a whole customized file into the docker container and overload the default one.

2) Be able to click to view other sparnatural demos. If I understand well, there is other demos into theses folders:
https://github.com/sparna-git/Sparnatural/tree/master/demos/
https://github.com/sparna-git/sparnatural.eu/tree/main/demos/
These sub-folders seams to have autonomous sparnatural demos (but each include a specific sparnatural.js and sparnatural.css file). Then I tried these demo copying the latest sparnatural.js and sparnatural.css but I noticed few demos does not works out of the box.
So, would it be a good idea to include all of these demo into the docker container? for example in a demo/ sub-folder in the nginx docker web server. The aim would be to give other easy examples for docker users.
If yes, is it a good idea do copy the latest sparnatural.js and sparnatural.css into these demo or should we just copy them like that with they own sparnatural.js/css version?

3) Make sparnatural versions consistent (and maybe use semantic versionning?). I looked at git tags and the latest tag is "6.0" but into the package.json the latest "version" field value is "3.0.0". If we autobuild docker images it would be great to build it following the sparnatural versions cycle. To have consistent versions, one easy way is to use the "npm version patch|minor|major" command line (https://docs.npmjs.com/cli/v8/commands/npm-version) so that git tag and package.json version is synchronized. Then, for the docker image build we could bind to this versioning workflow.
