### PR TITLE
Update demo URL and fix the line-number link to a commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It supports the creation of basic graph patterns with the selection of values wi
 
 ![](documentation/screencast-sparnatural-dbpedia-v3-en.gif)
 
-You can play with **online demos at http://sparnatural.eu#demos**.
+You can play with **online demos at http://sparnatural.eu/#demos**.
 
 # Getting Started
 
@@ -15,7 +15,7 @@ To get started :
 1. Read the following README;
 2. Read [the documentation](https://docs.sparnatural.eu)
 3. Look at how things work in file `sparnatural-demo-dbpedia/index.html`; 
-4. In particular look at how the specifications are written by looking at [the source of `sparnatural-demo-dbpedia/index.html`](https://github.com/sparna-git/Sparnatural/blob/master/sparnatural-demo-dbpedia/index.html#L100)
+4. In particular look at how the specifications are written by looking at [the source of `sparnatural-demo-dbpedia/index.html`](https://github.com/sparna-git/Sparnatural/blob/19dd3e30690c13dd0c820437111c45538e1d6472/sparnatural-demo-dbpedia/index.html#L100)
 5. Adapt `sparnatural-demo-dbpedia/index.html` by changing the configuration and adapting the SPARQL endpoint URL;
 
 To get started with docker :


### PR DESCRIPTION
Hi!

Learned about sparnatural today. Thanks for sharing!

The demos URL is missing a slash but my browser appears to be able to fix it when I open. But I thought it wouldn't hurt to fix it? Also changed the URL with the line-number to link to the commit instead of `master` so it doesn't become outdated if that file is changed.

Thanks!
-Bruno