### PR TITLE
Fix wrong import

### DIFF
--- a/src/sparnatural/statehandling/actions/GenerateQuery.ts
+++ b/src/sparnatural/statehandling/actions/GenerateQuery.ts
@@ -2,7 +2,7 @@ import { getSettings } from "../../../sparnatural/settings/defaultSettings";
 
 import ActionStore from "../ActionStore";
 import SparnaturalJsonGenerator from "../../generators/json/SparnaturalJsonGenerator";
-import SparqlGenerator from "../../generators/sparql/SparqlGenrator";
+import SparqlGenerator from "../../generators/sparql/SparqlGenerator";
 import {
   Generator
 } from "sparqljs";


### PR DESCRIPTION
When running the script `build-dev` I found, that an import statement contains a typo. I do not know why it runs error free in the repository build action, but this hindered me from actually using the program.

I just changed the import statement.

Here a partial output from webpack (all scss warning were omitted):

```
ERROR in ./src/sparnatural/statehandling/actions/GenerateQuery.ts 3:0-69
Module not found: Error: Can't resolve '../../generators/sparql/SparqlGenrator' in '/home/frand/sparnatural/src/sparnatural/statehandling/actions'
resolve '../../generators/sparql/SparqlGenrator' in '/home/frand/sparnatural/src/sparnatural/statehandling/actions'
  using description file: /home/frand/sparnatural/package.json (relative path: ./src/sparnatural/statehandling/actions)
    Field 'browser' doesn't contain a valid alias configuration
    using description file: /home/frand/sparnatural/package.json (relative path: ./src/sparnatural/generators/sparql/SparqlGenrator)
      no extension
        Field 'browser' doesn't contain a valid alias configuration
        /home/frand/sparnatural/src/sparnatural/generators/sparql/SparqlGenrator doesn't exist
      .tsx
        Field 'browser' doesn't contain a valid alias configuration
        /home/frand/sparnatural/src/sparnatural/generators/sparql/SparqlGenrator.tsx doesn't exist
      .ts
        Field 'browser' doesn't contain a valid alias configuration
        /home/frand/sparnatural/src/sparnatural/generators/sparql/SparqlGenrator.ts doesn't exist
      .js
        Field 'browser' doesn't contain a valid alias configuration
        /home/frand/sparnatural/src/sparnatural/generators/sparql/SparqlGenrator.js doesn't exist
      as directory
        /home/frand/sparnatural/src/sparnatural/generators/sparql/SparqlGenrator doesn't exist
 @ ./src/sparnatural/statehandling/ActionStore.ts 14:0-57 47:12-26 58:12-26 100:12-26 107:12-26 113:12-26 121:12-26 125:12-26
 @ ./src/sparnatural/components/SparnaturalComponent.ts 11:0-55 39:35-46
 @ ./src/SparnaturalElement.ts 6:0-81 33:31-51

ERROR in /home/frand/sparnatural/src/sparnatural/statehandling/actions/GenerateQuery.ts
./src/sparnatural/statehandling/actions/GenerateQuery.ts 5:28-68
[tsl] ERROR in /home/frand/sparnatural/src/sparnatural/statehandling/actions/GenerateQuery.ts(5,29)
      TS2307: Cannot find module '../../generators/sparql/SparqlGenrator' or its corresponding type declarations.
ts-loader-default_e3b0c44298fc1c14
 @ ./src/sparnatural/statehandling/ActionStore.ts 14:0-57 47:12-26 58:12-26 100:12-26 107:12-26 113:12-26 121:12-26 125:12-26
 @ ./src/sparnatural/components/SparnaturalComponent.ts 11:0-55 39:35-46
 @ ./src/SparnaturalElement.ts 6:0-81 33:31-51

webpack 5.93.0 compiled with 2 errors and 6 warnings in 9609 ms
```
