### PR TITLE
build: upgrade TypeScript to v5.x to fix build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "stream-browserify": "^3.0.0",
     "ts-jest": "^29.4.0",
     "ts-loader": "^9.3.0",
-    "typescript": "^4.9.5",
+    "typescript": "^5.9.3",
     "url": "^0.11.0",
     "url-loader": "^4.1.1",
     "util": "^0.12.4",


### PR DESCRIPTION
### Description
This PR upgrades TypeScript from 4.9.5 to 5.x to resolve several compilation errors (TS1383, TS2339) occurring with recent `@types` dependencies in `node_modules`.

### Changes
- Updated `typescript` to `^5.0.0` in `devDependencies`.
- Fixed compatibility with `@rdfjs/types` (no more `export type *` errors).
- Resolved conflicts with modern Node.js symbols (`Symbol.dispose`).

The build now runs successfully without requiring `skipLibCheck: true`.